### PR TITLE
Conda build updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on:
+- push
+- pull_request
 
 jobs:
   build:
@@ -22,6 +24,6 @@ jobs:
     - name: Basic test of GRASS GIS
       shell: bash -l {0}
       run: ./test_simple.sh
-    - name: Thorough test of GRASS GIS
-      shell: bash -l {0}
-      run: ./test_thorough.sh
+#    - name: Thorough test of GRASS GIS
+#      shell: bash -l {0}
+#      run: ./test_thorough.sh

--- a/configure.sh
+++ b/configure.sh
@@ -6,8 +6,10 @@ export GRASS_PYTHON=$(which pythonw)
 export CC=$PREFIX/bin/clang
 export CXX=$PREFIX/bin/clang++
 export MACOSX_DEPLOYMENT_TARGET=10.14
+export CONDA_BUILD_SYSROOT=$(xcrun --show-sdk-path)
 
 CONFIGURE_FLAGS="\
+  --with-macosx-sdk=$CONDA_BUILD_SYSROOT \
   --enable-64bit \
   --with-macosx-archs=x86_64 \
   --with-opengl=aqua \


### PR DESCRIPTION
The problem described in https://github.com/GRASS-GIS/grass-gis-experimental-ci/pull/2#issuecomment-665384471 was caused by missing env variable CONDA_BUILD_SYSROOT. We encountered this problem with Michael recently, but I didn't reckon it was needed if using the systems default SDK. Anyway, this should fix it.

I also temporary disabled the thorough test (it takes hours on this CI) until we get the build going, as well I added CI action on pull request (for the same reason).

[CI results](https://github.com/nilason/grass-gis-experimental-ci/actions/runs/186752338)